### PR TITLE
Powerstate optimization

### DIFF
--- a/yang/ietf-power-and-energy.txt
+++ b/yang/ietf-power-and-energy.txt
@@ -1,8 +1,8 @@
 module: ietf-power-and-energy
-  +--ro energy-objects
-     +--ro energy-entry* [object-id]
-        +--ro object-id              string
-        +--ro source-component-id?   -> /hw:hardware/component/name
+  +--rw energy-objects
+     +--rw energy-entry* [object-id]
+        +--rw object-id              string
+        +--rw source-component-id?   -> /hw:hardware/component/name
         +--ro power
         |  +--ro instantaneous-power     int32
         |  +--ro nameplate-power?        uint32
@@ -10,6 +10,10 @@ module: ietf-power-and-energy
         |  +--ro data-source-accuracy?   identityref
         |  +--ro power-factor?           power-factor
         |  +--ro measurement-local?      boolean
+        +--rw power-state
+        |  +--rw power-state-admin?    identityref
+        |  +--ro power-state-oper?     identityref
+        |  +--rw state-enter-reason?   identityref
         +--ro energy
         |  +--ro total-energy-consumed?    uint64
         |  +--ro total-energy-delivered?   uint64

--- a/yang/ietf-power-and-energy.txt
+++ b/yang/ietf-power-and-energy.txt
@@ -1,28 +1,32 @@
 module: ietf-power-and-energy
-  +--rw energy-objects
+  +--ro energy-objects
+  |  +--ro energy-entry* [object-id]
+  |     +--ro object-id              string
+  |     +--ro source-component-id?   -> /hw:hardware/component/name
+  |     +--ro power
+  |     |  +--ro instantaneous-power     int32
+  |     |  +--ro nameplate-power?        uint32
+  |     |  +--ro unit-multiplier         identityref
+  |     |  +--ro data-source-accuracy?   identityref
+  |     |  +--ro power-factor?           power-factor
+  |     |  +--ro measurement-local?      boolean
+  |     +--ro energy
+  |     |  +--ro total-energy-consumed?    uint64
+  |     |  +--ro total-energy-delivered?   uint64
+  |     |  +--ro unit-multiplier?          identityref
+  |     |  +--ro data-source-accuracy?     identityref
+  |     |  +--ro measurement-local?        boolean
+  |     |  +--ro certifications*           identityref
+  |     +--ro power-state
+  |     |  +--ro power-state-oper?   identityref
+  |     +--ro relationship* [type]
+  |        +--ro type    identityref
+  |        +--ro peer* [id]
+  |           +--ro id         string
+  |           +--ro details?   string
+  +--rw energy-control
      +--rw energy-entry* [object-id]
-        +--rw object-id              string
-        +--rw source-component-id?   -> /hw:hardware/component/name
-        +--ro power
-        |  +--ro instantaneous-power     int32
-        |  +--ro nameplate-power?        uint32
-        |  +--ro unit-multiplier         identityref
-        |  +--ro data-source-accuracy?   identityref
-        |  +--ro power-factor?           power-factor
-        |  +--ro measurement-local?      boolean
+        +--rw object-id      string
         +--rw power-state
-        |  +--rw power-state-admin?    identityref
-        |  +--ro power-state-oper?     identityref
-        |  +--rw state-enter-reason?   identityref
-        +--ro energy
-        |  +--ro total-energy-consumed?    uint64
-        |  +--ro total-energy-delivered?   uint64
-        |  +--ro unit-multiplier?          identityref
-        |  +--ro data-source-accuracy?     identityref
-        |  +--ro measurement-local?        boolean
-        |  +--ro certifications*           identityref
-        +--ro relationship* [type]
-           +--ro type    identityref
-           +--ro peer* [id]
-              +--ro id         string
-              +--ro details?   string
+           +--rw power-state-admin?    identityref
+           +--rw state-enter-reason?   identityref

--- a/yang/ietf-power-and-energy.yang
+++ b/yang/ietf-power-and-energy.yang
@@ -377,6 +377,18 @@ module ietf-power-and-energy {
     reference
       "RFC 7460: eoPowerStateEnterReason";
   }
+  identity power-state-on {
+    base power-state;
+    description "full power on.";
+    reference
+      "RFC 7460: PowerStateSet";
+  }
+  identity power-state-off {
+    base power-state;
+    description "power off.";
+    reference
+      "RFC 7460: PowerStateSet";
+  }
   identity unit-multiplier {
     description 
       "Base identity for unit multipliers as defined in IEC 61850-7-3
@@ -521,10 +533,11 @@ module ietf-power-and-energy {
   }
 
   container energy-objects {
+    config false;
     description
       "Energy objects container for power and energy attributes.";
     reference
-      "RFC 7460: eoPowerTable";
+      "RFC 7460: eoPowerTable, eoEnergyTable";
     
     list energy-entry {
       key "object-id";
@@ -533,7 +546,7 @@ module ietf-power-and-energy {
          Each entry contains the complete set of power and energy attributes
          for a specific physical component.";
       reference
-        "RFC 7460: EoPowerEntry";
+        "RFC 7460: eoPowerEntry, eoEnergyTable";
         
       leaf object-id {
         type string;
@@ -554,7 +567,6 @@ module ietf-power-and-energy {
       }
 
       container power {
-        config false;
         description
           "Container for power measurement attributes.";
         reference
@@ -645,46 +657,7 @@ module ietf-power-and-energy {
         }
       }
 
-      container power-state {
-        description
-          "Container for Power state management and monitoring.";
-        leaf power-state-admin {
-          type identityref {
-            base power-state-admin;
-          }
-          description
-            "The administratively requested power state for the 
-             Energy Object. This is the state that the management 
-             system desires the energy object to be in.";
-          reference
-            "RFC 7460: eoPowerAdminState";
-        }
-        leaf power-state-oper {
-          type identityref {
-            base power-state-oper;
-          }
-          config false;
-          description
-            "The actual operational power state of the Energy Object.
-             This reflects the current state, which may differ from the
-             admin-state during transitions.";
-          reference
-            "RFC 7460: eoPowerOperState";
-        }
-        leaf state-enter-reason {
-          type identityref {
-            base power-state-enter-reason;
-          }
-          description
-            "The reason why the Energy Object entered its current 
-             operational power state. This is set whenever the 
-             power-state-oper changes.";
-          reference
-            "RFC 7460: eoPowerStateEnterReason";
-        }
-      }
       container energy {
-        config false;
         description
           "Container for energy measurement attributes.";
         reference
@@ -772,6 +745,22 @@ module ietf-power-and-energy {
             this list is empty, the energy object has no certifications.";
         }    
       }
+      container power-state {
+        description
+          "Container for Power state monitoring.";
+        leaf power-state-oper {
+          type identityref {
+            base power-state-oper;
+          }
+          description
+            "The actual operational power state of the Energy Object.
+             This reflects the current state, which may differ from the
+             admin-state during transitions.";
+          reference
+            "RFC 7460: eoPowerOperState";
+        }
+      }
+
       list relationship {
         config false;
         key "type";
@@ -816,6 +805,64 @@ module ietf-power-and-energy {
                Useful when network level UUID of the peer is not
                known.";
           }
+        }
+      }
+    }
+  }
+  
+  container energy-control {
+    description
+      "Energy control configuration, mirroring monitored objects.";
+    reference
+      "RFC 7460: eoPowerTable";
+    list energy-entry {
+      key "object-id";
+      description
+        "Control entry for a specific energy object.";
+      reference
+        "RFC 7460: eoPowerEntry";
+      leaf object-id {
+        type leafref {
+          path "/energy-objects/energy-entry/object-id";
+        }
+        description "Reference to the monitored energy object.";
+      }
+      container power-state {
+        description
+          "Container for Power state management and monitoring.";
+        leaf power-state-admin {
+          type identityref {
+            base power-state-admin;
+          }
+          description
+            "The administratively requested power state for the 
+             Energy Object. This is the state that the management 
+             system desires the energy object to be in.";
+          reference
+            "RFC 7460: eoPowerAdminState";
+        }
+        leaf power-state-oper {
+          type identityref {
+            base power-state-oper;
+          }
+          config false;
+          description
+            "The actual operational power state of the Energy Object.
+             This reflects the current state, which may differ from the
+             admin-state during transitions.";
+          reference
+            "RFC 7460: eoPowerOperState";
+        }
+        leaf state-enter-reason {
+          type identityref {
+            base power-state-enter-reason;
+          }
+          description
+            "The reason why the Energy Object entered its current 
+             operational power state. This is set whenever the 
+             power-state-oper changes.";
+          reference
+            "RFC 7460: eoPowerStateEnterReason";
         }
       }
     }

--- a/yang/ietf-power-and-energy.yang
+++ b/yang/ietf-power-and-energy.yang
@@ -389,6 +389,12 @@ module ietf-power-and-energy {
     reference
       "RFC 7460: PowerStateSet";
   }
+  identity power-state-low-power {
+    base power-state;
+    description "low-power state.";
+    reference
+      "RFC 7460: PowerStateSet";
+  }
   identity unit-multiplier {
     description 
       "Base identity for unit multipliers as defined in IEC 61850-7-3
@@ -755,7 +761,11 @@ module ietf-power-and-energy {
           description
             "The actual operational power state of the Energy Object.
              This reflects the current state, which may differ from the
-             admin-state during transitions.";
+             admin-state during transitions. This leaf is the 
+             operational counterpart of the administratively set 
+             'power-state-admin' in /energy-control/energy-entry. The 
+             two leaves together form the complete power state 
+             management interface.";
           reference
             "RFC 7460: eoPowerOperState";
         }
@@ -839,7 +849,11 @@ module ietf-power-and-energy {
           description
             "The administratively requested power state for the 
              Energy Object. This is the state that the management 
-             system desires the energy object to be in.";
+             system desires the energy object to be in. This leaf is 
+             the administrative counterpart of the operational set 
+             'power-state-oper' in /energy-objects/energy-entry. The 
+             two leaves together form the complete power state 
+             management interface.";
           reference
             "RFC 7460: eoPowerAdminState";
         }

--- a/yang/ietf-power-and-energy.yang
+++ b/yang/ietf-power-and-energy.yang
@@ -348,7 +348,35 @@ module ietf-power-and-energy {
     reference
       "IANA: Power State Set Registry";
   }
-
+  identity power-state-admin {
+    base power-state;
+    description
+      "Base identity for administratively requested power states. The 
+       administrative power state indicates the desired power state 
+       requested for the Energy Object by a management system.";
+    reference
+      "RFC 7460: Section 5.3 (Power State)";
+  }
+  identity power-state-oper {
+    base power-state;
+    description
+      "Base identity for operational power states. The operational 
+       power state indicates the actual current power state of the 
+       Energy Object. A difference between the administrative state 
+       and the operational state indicates that the Energy Object is 
+       transitioning between power states.";
+    reference
+      "RFC 7460: Section 5.3 (Power State)";
+  }
+  identity power-state-enter-reason {
+    description
+      "Base identity for reasons why an Energy Object entered its 
+       current operational power state. This is analogous to the 
+       enumeration values defined for eoPowerStateEnterReason 
+       in RFC 7460.";
+    reference
+      "RFC 7460: eoPowerStateEnterReason";
+  }
   identity unit-multiplier {
     description 
       "Base identity for unit multipliers as defined in IEC 61850-7-3
@@ -493,7 +521,6 @@ module ietf-power-and-energy {
   }
 
   container energy-objects {
-    config false;
     description
       "Energy objects container for power and energy attributes.";
     reference
@@ -513,7 +540,7 @@ module ietf-power-and-energy {
         description
           "An identifier that uniquely identifies the energy object 
           in an energy object.";
-      }        
+      }
       
       leaf source-component-id {
         type leafref {
@@ -527,6 +554,7 @@ module ietf-power-and-energy {
       }
 
       container power {
+        config false;
         description
           "Container for power measurement attributes.";
         reference
@@ -616,7 +644,47 @@ module ietf-power-and-energy {
              "RFC 7460: eoPowerMeasurementLocal object";
         }
       }
+
+      container power-state {
+        description
+          "Container for Power state management and monitoring.";
+        leaf power-state-admin {
+          type identityref {
+            base power-state-admin;
+          }
+          description
+            "The administratively requested power state for the 
+             Energy Object. This is the state that the management 
+             system desires the energy object to be in.";
+          reference
+            "RFC 7460: eoPowerAdminState";
+        }
+        leaf power-state-oper {
+          type identityref {
+            base power-state-oper;
+          }
+          config false;
+          description
+            "The actual operational power state of the Energy Object.
+             This reflects the current state, which may differ from the
+             admin-state during transitions.";
+          reference
+            "RFC 7460: eoPowerOperState";
+        }
+        leaf state-enter-reason {
+          type identityref {
+            base power-state-enter-reason;
+          }
+          description
+            "The reason why the Energy Object entered its current 
+             operational power state. This is set whenever the 
+             power-state-oper changes.";
+          reference
+            "RFC 7460: eoPowerStateEnterReason";
+        }
+      }
       container energy {
+        config false;
         description
           "Container for energy measurement attributes.";
         reference
@@ -705,6 +773,7 @@ module ietf-power-and-energy {
         }    
       }
       list relationship {
+        config false;
         key "type";
         description "Relationships for this energy entry. Replaces 
         RFC 7461 eoRelationTable.";

--- a/yang/ietf-power-and-energy.yang
+++ b/yang/ietf-power-and-energy.yang
@@ -822,10 +822,12 @@ module ietf-power-and-energy {
       reference
         "RFC 7460: eoPowerEntry";
       leaf object-id {
-        type leafref {
-          path "/energy-objects/energy-entry/object-id";
+        type string;
+        description "Must match an existing energy-object object-id.";
+        must "/energy-objects/energy-entry[object-id=current()]" {
+          error-message "The referenced object-id does not exist in 
+                         energy-objects.";
         }
-        description "Reference to the monitored energy object.";
       }
       container power-state {
         description
@@ -840,18 +842,6 @@ module ietf-power-and-energy {
              system desires the energy object to be in.";
           reference
             "RFC 7460: eoPowerAdminState";
-        }
-        leaf power-state-oper {
-          type identityref {
-            base power-state-oper;
-          }
-          config false;
-          description
-            "The actual operational power state of the Energy Object.
-             This reflects the current state, which may differ from the
-             admin-state during transitions.";
-          reference
-            "RFC 7460: eoPowerOperState";
         }
         leaf state-enter-reason {
           type identityref {


### PR DESCRIPTION
1. seperate power state monitoring and power state control;
2. clarify that power-state-oper leaf in the monitoring part should be looked at as a whole with oper-state-admin leaf in the control part;
3. add three power states including on, off and low-power as initial input, further states  will be discussed in more details in the future.