### PR TITLE
change power-enter-reason type from identity to string

### DIFF
--- a/yang/ietf-power-and-energy.yang
+++ b/yang/ietf-power-and-energy.yang
@@ -363,13 +363,6 @@ module ietf-power-and-energy {
        and the operational state indicates that the Energy Object is 
        transitioning between power states.";
   }
-  identity power-state-enter-reason {
-    description
-      "Base identity for reasons why an Energy Object entered its 
-       current operational power state. This is analogous to the 
-       enumeration values defined for eoPowerStateEnterReason 
-       in RFC 7460.";
-  }
   identity power-state-on {
     base power-state;
     description "full power on.";
@@ -819,9 +812,7 @@ module ietf-power-and-energy {
         }
         
         leaf state-enter-reason {
-          type identityref {
-            base power-state-enter-reason;
-          }
+          type string;
           description
             "The reason why the Energy Object entered its current 
              operational power state. This is set whenever the 


### PR DESCRIPTION
As decided on the design team meeting today, the type of power-enter-reason should be changed from identity to reason unless there is clear usecase for the demand of identity.