### PR TITLE
remove state-enter-reason identity and following IANA feedback

### DIFF
--- a/.includes.mk
+++ b/.includes.mk
@@ -1,3 +1,3 @@
 draft-bcmj-green-power-and-energy-yang.xml: yang/ietf-power-and-energy.txt
 draft-bcmj-green-power-and-energy-yang.xml: yang/ietf-power-and-energy.yang
-draft-bcmj-green-power-and-energy-yang.xml: yang/ietf-iana-power-and-energy.yang
+draft-bcmj-green-power-and-energy-yang.xml: yang/iana-ietf-power-and-energy.yang

--- a/draft-bcmj-green-power-and-energy-yang.md
+++ b/draft-bcmj-green-power-and-energy-yang.md
@@ -278,9 +278,9 @@ The IANA requested identities for power and energy class are separately
 described below.
 
 ~~~~ yang
-{::include yang/ietf-iana-power-and-energy.yang}
+{::include yang/iana-ietf-power-and-energy.yang}
 ~~~~
-{: sourcecode-markers="true" sourcecode-name="ietf-iana-power-and-energy.yang”}
+{: sourcecode-markers="true" sourcecode-name="iana-ietf-power-and-energy.yang”}
 # Operational Considerations
 
 Heterogeneous sensor capabilities across components complicate power
@@ -410,23 +410,23 @@ This document requests IANA to create and maintain a new registry group called "
 
 | Field       | Value                                                   |
 |-------------|---------------------------------------------------------|
-| Name        | ietf-iana-power-and-energy                              |
-| Namespace   | urn:ietf:params:xml:ns:yang:ietf-iana-power-and-energy  |
+| Name        | iana-ietf-power-and-energy                              |
+| Namespace   | urn:ietf:params:xml:ns:yang:iana-ietf-power-and-energy  |
 | Prefix      | ianaeo                                                  |
 | Reference   | RFC XXXX                                                |
 
 Note to IANA: RFC XXXX must be replaced by the newly assigned RFC
 number.
 
-All sub-registries defined in this document are part of the "Power and Energy" registry group.
+All registries defined in this document are part of the "Power and Energy" registry group.
 
 
 ## GREEN Certification Type Registry
 
-This document requests IANA to create a new sub-registry called "Power and Energy Certification Types" within the "Power and Energy" registry group.
+This document requests IANA to create a new registry called "Power and Energy Certification Types" within the "Power and Energy" registry group.
 
 This document defines the initial version of the IANA-maintained
-`certification-type` identity in the `ietf-iana-power-and-energy` YANG
+`certification-type` identity in the `iana-ietf-power-and-energy` YANG
 module. The registry assigns string identity names for power and energy efficiency certification types, for use as identityref values in "ietf-power-and-energy" YANG module. The registered value is the unqualified identity name (e.g., energy-star, c80-plus, etc). No numeric code points are assigned by this registry.
 
 New entries to "Power and Energy Certification Types" registry
@@ -441,7 +441,7 @@ verify that:
   from the official certification name.
 
 When a new certification type is added to the registry, a new
-`identity` statement MUST be added to the `ietf-iana-power-and-energy`
+`identity` statement MUST be added to the `iana-ietf-power-and-energy`
 YANG module. The following substatements to the `identity` statement
 MUST be defined:
 
@@ -458,15 +458,15 @@ Unassigned or reserved values MUST NOT be present in the module.
 
 When the "Power and Energy Certification Types" registry is
 updated with a new entry, a corresponding new `identity` statement
-MUST be added to the `ietf-iana-power-and-energy` YANG module, and a new revision statement MUST be added in front of the existing revision
+MUST be added to the `iana-ietf-power-and-energy` YANG module, and a new revision statement MUST be added in front of the existing revision
 statements.
 
 IANA is requested to add the following note to the "Power and Energy Certification Types" registry:
 
 Certification types MUST NOT be directly added to the
-ietf-iana-power-and-energy YANG module. They MUST instead be added to the
+iana-ietf-power-and-energy YANG module. They MUST instead be added to the
 "Power and Energy Certification Types" registry. When this registry
-is updated, the ietf-iana-power-and-energy YANG module MUST be updated as
+is updated, the iana-ietf-power-and-energy YANG module MUST be updated as
 defined in RFC XXXX.
 
 # Acknowledgments

--- a/yang/iana-ietf-power-and-energy.yang
+++ b/yang/iana-ietf-power-and-energy.yang
@@ -1,6 +1,6 @@
-module ietf-iana-power-and-energy {
+module iana-ietf-power-and-energy {
   yang-version 1.1;
-  namespace "urn:ietf:params:xml:ns:yang:ietf-iana-power-and-energy";
+  namespace "urn:ietf:params:xml:ns:yang:iana-ietf-power-and-energy";
   prefix ianaeo;
 
   organization "IANA";

--- a/yang/ietf-power-and-energy.txt
+++ b/yang/ietf-power-and-energy.txt
@@ -28,6 +28,5 @@ module: ietf-power-and-energy
      +--rw energy-entry* [object-id]
         +--rw object-id      string
         +--rw power-state
-           +--rw power-state-oper?     -> /energy-objects/energy-entry/power-state/power-state-oper
-           +--rw power-state-admin?    identityref
-           +--rw state-enter-reason?   identityref
+           +--rw power-state-oper?    -> /energy-objects/energy-entry/power-state/power-state-oper
+           +--rw power-state-admin?   identityref

--- a/yang/ietf-power-and-energy.yang
+++ b/yang/ietf-power-and-energy.yang
@@ -10,7 +10,7 @@ module ietf-power-and-energy {
       "RFC 8348: A YANG Data Model for Hardware Management";
   }
   
-  import ietf-iana-power-and-energy {
+  import iana-ietf-power-and-energy {
     prefix ianaeo;
     reference
       "IANA-defined identities for power and energy class";
@@ -362,13 +362,6 @@ module ietf-power-and-energy {
        Energy Object. A difference between the administrative state 
        and the operational state indicates that the Energy Object is 
        transitioning between power states.";
-  }
-  identity power-state-enter-reason {
-    description
-      "Base identity for reasons why an Energy Object entered its 
-       current operational power state. This is analogous to the 
-       enumeration values defined for eoPowerStateEnterReason 
-       in RFC 7460.";
   }
   identity power-state-on {
     base power-state;
@@ -816,16 +809,6 @@ module ietf-power-and-energy {
              'power-state-oper' in /energy-objects/energy-entry. The 
              two leaves together form the complete power state 
              management interface.";
-        }
-        
-        leaf state-enter-reason {
-          type identityref {
-            base power-state-enter-reason;
-          }
-          description
-            "The reason why the Energy Object entered its current 
-             operational power state. This is set whenever the 
-             power-state-oper changes.";
         }
       }
     }


### PR DESCRIPTION
1. as decided by green-design-team that state-enter-reason should be removed this time and can add it back in the future if required by specific usecase.
2. adding Marisol's update with iana prefix following IANA feedback.