### PR TITLE
fix the pyang warnings and optimize according to Per and Benoit's feedback.

### DIFF
--- a/draft-bcmj-green-power-and-energy-yang.md
+++ b/draft-bcmj-green-power-and-energy-yang.md
@@ -205,7 +205,7 @@ required-instance false leafref to operational tree instance.
 ~~~~ yangtree
 {::include yang/ietf-power-and-energy.txt}
 ~~~~
-{: markers="true" name="ietf-power-and-energy@2025-12.txt”}
+{: markers="true" name="ietf-power-and-energy@2026-05-27.txt"}
 
 # Relationship to the Hardware YANG Data Model
 
@@ -272,7 +272,7 @@ of network devices and the components on these devices.
 ~~~~ yang
 {::include yang/ietf-power-and-energy.yang}
 ~~~~
-{: sourcecode-markers="true" sourcecode-name="ietf-power-and-energy.yang”}
+{: sourcecode-markers="true" sourcecode-name="ietf-power-and-energy@2026-05-27.yang"}
 
 The IANA requested identities for power and energy class are separately
 described below.
@@ -280,7 +280,7 @@ described below.
 ~~~~ yang
 {::include yang/iana-ietf-power-and-energy.yang}
 ~~~~
-{: sourcecode-markers="true" sourcecode-name="iana-ietf-power-and-energy.yang”}
+{: sourcecode-markers="true" sourcecode-name="iana-ietf-power-and-energy@2026-05-27.yang"}
 # Operational Considerations
 
 Heterogeneous sensor capabilities across components complicate power

--- a/draft-ietf-green-power-and-energy-yang.md
+++ b/draft-ietf-green-power-and-energy-yang.md
@@ -1,7 +1,7 @@
 ---
 title: Power and Energy YANG Module
 abbrev: GREEN-PEM-YANG
-docname: draft-bcmj-green-power-and-energy-yang-latest
+docname: draft-ietf-green-power-and-energy-yang-latest
 category: std
 submissionType: IETF
 
@@ -215,7 +215,7 @@ three identifiers for hardware components, which are "name",
 "physical-index" and "uuid". Among them, "name" is the key to "List of
 components", "physical-index" matches entPhysicalIndex in the legacy
 Entity MIB {{?RFC6933}} if it exists, and UUID is the Universally
-Unified IDentifier {{?RFC4122}} of the component.
+Unified IDentifier {{?RFC9562}} of the component.
 
 In the Power and Energy YANG Module defined in this specification,
 there is a leaf named "source-component-id" which refers to the

--- a/yang/iana-ietf-power-and-energy.yang
+++ b/yang/iana-ietf-power-and-energy.yang
@@ -39,13 +39,21 @@ module iana-ietf-power-and-energy {
   reference
     "https://www.iana.org/assignments/yang-parameters";
 
+  revision 2026-05-27 {
+    description
+      "Marisol's update following IANA feedback;";
+    reference
+      "RFC XXX: A YANG Data Model for Power and Energy monitoring and 
+       control of devices within or connected to communication 
+       networks";
+  }  
   revision 2026-02-26 {
     description
       "Initial revision.";
     reference
       "RFC XXX: A YANG Data Model for Power and Energy monitoring and 
-     control of devices within or connected to communication 
-     networks";
+       control of devices within or connected to communication 
+       networks";
   }
 
   identity certification-type {

--- a/yang/iana-ietf-power-and-energy.yang
+++ b/yang/iana-ietf-power-and-energy.yang
@@ -24,18 +24,22 @@ module iana-ietf-power-and-energy {
      Requests for new values should be made to IANA via
      email (iana@iana.org).
 
+     The key words 'MUST', 'MUST NOT', 'REQUIRED', 'SHALL', 'SHALL
+     NOT', 'SHOULD', 'SHOULD NOT', 'RECOMMENDED', 'NOT RECOMMENDED',
+     'MAY', and 'OPTIONAL' in this document are to be interpreted as
+     described in BCP 14 (RFC 2119) (RFC 8174) when, and only when,
+     they appear in all capitals, as shown here.
+     
      Copyright (c) 2026 IETF Trust and the persons identified as
      authors of the code.  All rights reserved.
 
      Redistribution and use in source and binary forms, with or
-     without modification, is permitted pursuant to, and subject
-     to the license terms contained in, the Simplified BSD License
-     set forth in Section 4.c of the IETF Trust's Legal Provisions
+     without modification, is permitted pursuant to, and subject to
+     the license terms contained in, the Revised BSD License set
+     forth in Section 4.c of the IETF Trust's Legal Provisions
      Relating to IETF Documents
-     (https://trustee.ietf.org/license-info).
+     (https://trustee.ietf.org/license-info).";
 
-     The initial version of this YANG module is part of RFC XXX;
-     see the RFC itself for full legal notices.";
   reference
     "https://www.iana.org/assignments/yang-parameters";
 

--- a/yang/ietf-power-and-energy.txt
+++ b/yang/ietf-power-and-energy.txt
@@ -22,7 +22,7 @@ module: ietf-power-and-energy
   |     +--ro relationship* [type]
   |        +--ro type    identityref
   |        +--ro peer* [id]
-  |           +--ro id         string
+  |           +--ro id         yang:uuid
   |           +--ro details?   string
   +--rw energy-control
      +--rw energy-entry* [object-id]

--- a/yang/ietf-power-and-energy.yang
+++ b/yang/ietf-power-and-energy.yang
@@ -10,6 +10,12 @@ module ietf-power-and-energy {
       "RFC 8348: A YANG Data Model for Hardware Management";
   }
   
+  import ietf-yang-types {
+    prefix yang;
+    reference
+      "RFC 9911: Common YANG Data Types";
+  }
+
   import iana-ietf-power-and-energy {
     prefix ianaeo;
     reference
@@ -27,19 +33,24 @@ module ietf-power-and-energy {
   
   description
     "This YANG module specifies for Power and Energy monitoring and 
-     control of devices within or connected to communication 
-     networks.
+     control of devices within or connected to communication networks.
      
-     Copyright (c) 2025 IETF Trust and the persons identified as
-     authors of the code. All rights reserved.
+     The key words 'MUST', 'MUST NOT', 'REQUIRED', 'SHALL', 'SHALL
+     NOT', 'SHOULD', 'SHOULD NOT', 'RECOMMENDED', 'NOT RECOMMENDED',
+     'MAY', and 'OPTIONAL' in this document are to be interpreted as
+     described in BCP 14 (RFC 2119) (RFC 8174) when, and only when,
+     they appear in all capitals, as shown here.
      
+     Copyright (c) 2026 IETF Trust and the persons identified as
+     authors of the code.  All rights reserved.
+
      Redistribution and use in source and binary forms, with or
      without modification, is permitted pursuant to, and subject to
-     the license terms contained in, the Simplified BSD License set
+     the license terms contained in, the Revised BSD License set
      forth in Section 4.c of the IETF Trust's Legal Provisions
      Relating to IETF Documents
      (https://trustee.ietf.org/license-info).
-     
+
      This version of this YANG module is part of RFC XXXX
      (https://www.rfc-editor.org/info/rfcXXXX); see the RFC itself
      for full legal notices.";
@@ -753,20 +764,14 @@ module ietf-power-and-energy {
           description "Multiple peers for this relationship type.";
           
           leaf id {
-            type string;
-            description "This id specifies the Universally Unique
-              Identifier (UUID) of the peer (other) Energy Object that
-              this energy object is powering/powered-by/metering/
-              metered-by, etc. If the network level UUID is not known,
-              some other locally unique identifier MAY be used, in
-              conjunction with a human readable details.";
+            type yang:uuid;
+            description "The UUID of the peer energy entry, as defined 
+                         in RFC 9562.";
           }
           leaf details {
             type string;
             description 
-              "Human-readable details of the peer relationship.
-               Useful when network level UUID of the peer is not
-               known.";
+              "Additional details about the relationship.";
           }
         }
       }

--- a/yang/ietf-power-and-energy.yang
+++ b/yang/ietf-power-and-energy.yang
@@ -43,7 +43,16 @@ module ietf-power-and-energy {
      This version of this YANG module is part of RFC XXXX
      (https://www.rfc-editor.org/info/rfcXXXX); see the RFC itself
      for full legal notices.";
-  
+
+  revision 2026-05-27 {
+    description
+      "state-enter-reason identity removed; adding leafref from config tree 
+       instance to oper tree instance; remove references to EMAN and 
+       clarify it in the framework draft; comment in the draft on NMDA 
+       design.";
+    reference
+      "RFC XXXX: Energy Object YANG Data Model";
+  }  
   revision 2026-01-22 {
     description
       "Initial revision";


### PR DESCRIPTION
1. fix the issue of file name missing behind the "code begins" according to Benoit's feedback.
2. fix pyang warning info (modify YANG module descriptions complyinig with the required text from RFC 8174 , etc.) 
3. change relationship peer id type from string to uuid according to Per's CoW feedback;
4. update reference from rfc4122 to rfc9562 according to Per's CoW feedback;
5. change title to comply with working group draft requirements;