### PR TITLE
no relationship configuration on the device YANG module

### DIFF
--- a/draft-ietf-green-power-and-energy-yang.md
+++ b/draft-ietf-green-power-and-energy-yang.md
@@ -202,6 +202,26 @@ document.
 Finally, note that the instance is in the configuration tree, having a
 required-instance false leafref to operational tree instance.
 
+Regarding relationships among Energy Objects, this document does not
+provide a mechanism to configure relationships on the device (i.e.,
+there is no relationship list under /energy-control); the
+relationship list under /energy-objects/energy-entry is read-only
+operational data (config false).
+
+For relationships between components within the same device (e.g.,
+between a Line Processing Unit (LPU) and a Switch Fabric Unit (SFU)),
+the device can typically determine and populate this data directly,
+without requiring external configuration.
+
+Relationships between Energy Objects located on different devices are
+generally established and maintained at the controller or Energy
+Management System (EnMS) level, which has visibility into the
+broader network topology, as discussed in
+{{?I-D.ietf-green-framework-01}}. A device may still report a known
+inter-device relationship (e.g., using the peer's network-level UUID)
+when it has been made aware of it, but this module does not provide a
+mechanism to configure such relationships on the device itself.
+
 ~~~~ yangtree
 {::include yang/ietf-power-and-energy.txt}
 ~~~~

--- a/draft-ietf-green-power-and-energy-yang.md
+++ b/draft-ietf-green-power-and-energy-yang.md
@@ -202,6 +202,23 @@ document.
 Finally, note that the instance is in the configuration tree, having a
 required-instance false leafref to operational tree instance.
 
+The relationship list models the relationship between an Energy
+Object and its peer Energy Objects, using the
+energy-relationship-type identities: powered-by and powering (Power
+Source Relationship), metered-by and metering (Metering
+Relationship), and aggregated-by and aggregating (Aggregation
+Relationship). Each pair of identities expresses the same
+relationship from the perspective of each participant (e.g., if
+Energy Object A is powered-by Energy Object B, then Energy Object B
+is powering Energy Object A). These three relationship categories,
+including their use for power/metering topology discovery and for
+preventing double-counting of Energy values, are defined in
+{{?I-D.ietf-green-framework-01}}. For each relationship type, one or
+more peer Energy Objects can be identified via the `id` leaf within
+the `peer` list, a string value that is typically the peer's UUID
+when known, or another locally unique identifier, together with
+human-readable details captured in the `details` leaf, otherwise.
+
 Regarding relationships among Energy Objects, this document does not
 provide a mechanism to configure relationships on the device (i.e.,
 there is no relationship list under /energy-control); the

--- a/draft-ietf-green-power-and-energy-yang.txt
+++ b/draft-ietf-green-power-and-energy-yang.txt
@@ -214,10 +214,10 @@ Internet-Draft               GREEN-PEM-YANG                    July 2026
    Finally, note that the instance is in the configuration tree, having
    a required-instance false leafref to operational tree instance.
 
-
-
-
-
+   The relationship list models the relationship between an Energy
+   Object and its peer Energy Objects, using the energy-relationship-
+   type identities: powered-by and powering (Power Source Relationship),
+   metered-by and metering (Metering Relationship), and aggregated-by
 
 
 
@@ -225,6 +225,19 @@ Benoit, et al.           Expires 3 January 2027                 [Page 4]
 
 Internet-Draft               GREEN-PEM-YANG                    July 2026
 
+
+   and aggregating (Aggregation Relationship).  Each pair of identities
+   expresses the same relationship from the perspective of each
+   participant (e.g., if Energy Object A is powered-by Energy Object B,
+   then Energy Object B is powering Energy Object A).  These three
+   relationship categories, including their use for power/metering
+   topology discovery and for preventing double-counting of Energy
+   values, are defined in [I-D.ietf-green-framework-01].  For each
+   relationship type, one or more peer Energy Objects can be identified
+   via the id leaf within the peer list, a string value that is
+   typically the peer's UUID when known, or another locally unique
+   identifier, together with human-readable details captured in the
+   details leaf, otherwise.
 
    Regarding relationships among Energy Objects, this document does not
    provide a mechanism to configure relationships on the device (i.e.,
@@ -245,19 +258,6 @@ Internet-Draft               GREEN-PEM-YANG                    July 2026
    using the peer's network-level UUID) when it has been made aware of
    it, but this module does not provide a mechanism to configure such
    relationships on the device itself.
-
-
-
-
-
-
-
-
-
-
-
-
-
 
 
 

--- a/draft-ietf-green-power-and-energy-yang.txt
+++ b/draft-ietf-green-power-and-energy-yang.txt
@@ -73,20 +73,20 @@ Table of Contents
      1.1.  Terminology . . . . . . . . . . . . . . . . . . . . . . .   3
    2.  The GREEN Framework . . . . . . . . . . . . . . . . . . . . .   4
    3.  Power and Energy Data Model . . . . . . . . . . . . . . . . .   4
-   4.  Relationship to the Hardware YANG Data Model  . . . . . . . .   5
-   5.  Relationship to the EMAN Work . . . . . . . . . . . . . . . .   6
-   6.  Power and Energy YANG Module  . . . . . . . . . . . . . . . .   6
-   7.  Operational Considerations  . . . . . . . . . . . . . . . . .  27
-     7.1.  Measurement Accuracy and Data Source Classification . . .  27
-     7.2.  Industry-Standard Certifications  . . . . . . . . . . . .  29
-   8.  Security Considerations . . . . . . . . . . . . . . . . . . .  30
-   9.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  32
-     9.1.  GREEN Certification Type Registry . . . . . . . . . . . .  32
-   10. Acknowledgments . . . . . . . . . . . . . . . . . . . . . . .  34
-   11. References  . . . . . . . . . . . . . . . . . . . . . . . . .  34
-     11.1.  Normative References . . . . . . . . . . . . . . . . . .  34
-     11.2.  Informative References . . . . . . . . . . . . . . . . .  35
-   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  36
+   4.  Relationship to the Hardware YANG Data Model  . . . . . . . .   6
+   5.  Relationship to the EMAN Work . . . . . . . . . . . . . . . .   7
+   6.  Power and Energy YANG Module  . . . . . . . . . . . . . . . .   7
+   7.  Operational Considerations  . . . . . . . . . . . . . . . . .  28
+     7.1.  Measurement Accuracy and Data Source Classification . . .  28
+     7.2.  Industry-Standard Certifications  . . . . . . . . . . . .  30
+   8.  Security Considerations . . . . . . . . . . . . . . . . . . .  31
+   9.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  33
+     9.1.  GREEN Certification Type Registry . . . . . . . . . . . .  33
+   10. Acknowledgments . . . . . . . . . . . . . . . . . . . . . . .  35
+   11. References  . . . . . . . . . . . . . . . . . . . . . . . . .  35
+     11.1.  Normative References . . . . . . . . . . . . . . . . . .  35
+     11.2.  Informative References . . . . . . . . . . . . . . . . .  36
+   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  37
 
 1.  Introduction
 
@@ -226,6 +226,62 @@ Benoit, et al.           Expires 3 January 2027                 [Page 4]
 Internet-Draft               GREEN-PEM-YANG                    July 2026
 
 
+   Regarding relationships among Energy Objects, this document does not
+   provide a mechanism to configure relationships on the device (i.e.,
+   there is no relationship list under /energy-control); the
+   relationship list under /energy-objects/energy-entry is read-only
+   operational data (config false).
+
+   For relationships between components within the same device (e.g.,
+   between a Line Processing Unit (LPU) and a Switch Fabric Unit (SFU)),
+   the device can typically determine and populate this data directly,
+   without requiring external configuration.
+
+   Relationships between Energy Objects located on different devices are
+   generally established and maintained at the controller or Energy
+   Management System (EnMS) level, which has visibility into the broader
+   network topology, as discussed in [I-D.ietf-green-framework-01].  A
+   device may still report a known inter-device relationship (e.g.,
+   using the peer's network-level UUID) when it has been made aware of
+   it, but this module does not provide a mechanism to configure such
+   relationships on the device itself.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Benoit, et al.           Expires 3 January 2027                 [Page 5]
+
+Internet-Draft               GREEN-PEM-YANG                    July 2026
+
+
    module: ietf-power-and-energy
      +--ro energy-objects
      |  +--ro energy-entry* [object-id]
@@ -277,7 +333,7 @@ Internet-Draft               GREEN-PEM-YANG                    July 2026
 
 
 
-Benoit, et al.           Expires 3 January 2027                 [Page 5]
+Benoit, et al.           Expires 3 January 2027                 [Page 6]
 
 Internet-Draft               GREEN-PEM-YANG                    July 2026
 
@@ -333,7 +389,7 @@ Internet-Draft               GREEN-PEM-YANG                    July 2026
 
 
 
-Benoit, et al.           Expires 3 January 2027                 [Page 6]
+Benoit, et al.           Expires 3 January 2027                 [Page 7]
 
 Internet-Draft               GREEN-PEM-YANG                    July 2026
 
@@ -389,7 +445,7 @@ Internet-Draft               GREEN-PEM-YANG                    July 2026
 
 
 
-Benoit, et al.           Expires 3 January 2027                 [Page 7]
+Benoit, et al.           Expires 3 January 2027                 [Page 8]
 
 Internet-Draft               GREEN-PEM-YANG                    July 2026
 
@@ -445,7 +501,7 @@ Internet-Draft               GREEN-PEM-YANG                    July 2026
 
 
 
-Benoit, et al.           Expires 3 January 2027                 [Page 8]
+Benoit, et al.           Expires 3 January 2027                 [Page 9]
 
 Internet-Draft               GREEN-PEM-YANG                    July 2026
 
@@ -501,7 +557,7 @@ Internet-Draft               GREEN-PEM-YANG                    July 2026
 
 
 
-Benoit, et al.           Expires 3 January 2027                 [Page 9]
+Benoit, et al.           Expires 3 January 2027                [Page 10]
 
 Internet-Draft               GREEN-PEM-YANG                    July 2026
 
@@ -557,7 +613,7 @@ Internet-Draft               GREEN-PEM-YANG                    July 2026
 
 
 
-Benoit, et al.           Expires 3 January 2027                [Page 10]
+Benoit, et al.           Expires 3 January 2027                [Page 11]
 
 Internet-Draft               GREEN-PEM-YANG                    July 2026
 
@@ -613,7 +669,7 @@ Internet-Draft               GREEN-PEM-YANG                    July 2026
 
 
 
-Benoit, et al.           Expires 3 January 2027                [Page 11]
+Benoit, et al.           Expires 3 January 2027                [Page 12]
 
 Internet-Draft               GREEN-PEM-YANG                    July 2026
 
@@ -669,7 +725,7 @@ Internet-Draft               GREEN-PEM-YANG                    July 2026
 
 
 
-Benoit, et al.           Expires 3 January 2027                [Page 12]
+Benoit, et al.           Expires 3 January 2027                [Page 13]
 
 Internet-Draft               GREEN-PEM-YANG                    July 2026
 
@@ -725,7 +781,7 @@ Internet-Draft               GREEN-PEM-YANG                    July 2026
 
 
 
-Benoit, et al.           Expires 3 January 2027                [Page 13]
+Benoit, et al.           Expires 3 January 2027                [Page 14]
 
 Internet-Draft               GREEN-PEM-YANG                    July 2026
 
@@ -781,7 +837,7 @@ Internet-Draft               GREEN-PEM-YANG                    July 2026
 
 
 
-Benoit, et al.           Expires 3 January 2027                [Page 14]
+Benoit, et al.           Expires 3 January 2027                [Page 15]
 
 Internet-Draft               GREEN-PEM-YANG                    July 2026
 
@@ -837,7 +893,7 @@ Internet-Draft               GREEN-PEM-YANG                    July 2026
 
 
 
-Benoit, et al.           Expires 3 January 2027                [Page 15]
+Benoit, et al.           Expires 3 January 2027                [Page 16]
 
 Internet-Draft               GREEN-PEM-YANG                    July 2026
 
@@ -893,7 +949,7 @@ Internet-Draft               GREEN-PEM-YANG                    July 2026
 
 
 
-Benoit, et al.           Expires 3 January 2027                [Page 16]
+Benoit, et al.           Expires 3 January 2027                [Page 17]
 
 Internet-Draft               GREEN-PEM-YANG                    July 2026
 
@@ -949,7 +1005,7 @@ Internet-Draft               GREEN-PEM-YANG                    July 2026
 
 
 
-Benoit, et al.           Expires 3 January 2027                [Page 17]
+Benoit, et al.           Expires 3 January 2027                [Page 18]
 
 Internet-Draft               GREEN-PEM-YANG                    July 2026
 
@@ -1005,7 +1061,7 @@ Internet-Draft               GREEN-PEM-YANG                    July 2026
 
 
 
-Benoit, et al.           Expires 3 January 2027                [Page 18]
+Benoit, et al.           Expires 3 January 2027                [Page 19]
 
 Internet-Draft               GREEN-PEM-YANG                    July 2026
 
@@ -1061,7 +1117,7 @@ Internet-Draft               GREEN-PEM-YANG                    July 2026
 
 
 
-Benoit, et al.           Expires 3 January 2027                [Page 19]
+Benoit, et al.           Expires 3 January 2027                [Page 20]
 
 Internet-Draft               GREEN-PEM-YANG                    July 2026
 
@@ -1117,7 +1173,7 @@ Internet-Draft               GREEN-PEM-YANG                    July 2026
 
 
 
-Benoit, et al.           Expires 3 January 2027                [Page 20]
+Benoit, et al.           Expires 3 January 2027                [Page 21]
 
 Internet-Draft               GREEN-PEM-YANG                    July 2026
 
@@ -1173,7 +1229,7 @@ Internet-Draft               GREEN-PEM-YANG                    July 2026
 
 
 
-Benoit, et al.           Expires 3 January 2027                [Page 21]
+Benoit, et al.           Expires 3 January 2027                [Page 22]
 
 Internet-Draft               GREEN-PEM-YANG                    July 2026
 
@@ -1229,7 +1285,7 @@ Internet-Draft               GREEN-PEM-YANG                    July 2026
 
 
 
-Benoit, et al.           Expires 3 January 2027                [Page 22]
+Benoit, et al.           Expires 3 January 2027                [Page 23]
 
 Internet-Draft               GREEN-PEM-YANG                    July 2026
 
@@ -1285,7 +1341,7 @@ Internet-Draft               GREEN-PEM-YANG                    July 2026
 
 
 
-Benoit, et al.           Expires 3 January 2027                [Page 23]
+Benoit, et al.           Expires 3 January 2027                [Page 24]
 
 Internet-Draft               GREEN-PEM-YANG                    July 2026
 
@@ -1341,7 +1397,7 @@ Internet-Draft               GREEN-PEM-YANG                    July 2026
 
 
 
-Benoit, et al.           Expires 3 January 2027                [Page 24]
+Benoit, et al.           Expires 3 January 2027                [Page 25]
 
 Internet-Draft               GREEN-PEM-YANG                    July 2026
 
@@ -1397,7 +1453,7 @@ Internet-Draft               GREEN-PEM-YANG                    July 2026
 
 
 
-Benoit, et al.           Expires 3 January 2027                [Page 25]
+Benoit, et al.           Expires 3 January 2027                [Page 26]
 
 Internet-Draft               GREEN-PEM-YANG                    July 2026
 
@@ -1453,7 +1509,7 @@ Internet-Draft               GREEN-PEM-YANG                    July 2026
 
 
 
-Benoit, et al.           Expires 3 January 2027                [Page 26]
+Benoit, et al.           Expires 3 January 2027                [Page 27]
 
 Internet-Draft               GREEN-PEM-YANG                    July 2026
 
@@ -1509,7 +1565,7 @@ Internet-Draft               GREEN-PEM-YANG                    July 2026
 
 
 
-Benoit, et al.           Expires 3 January 2027                [Page 27]
+Benoit, et al.           Expires 3 January 2027                [Page 28]
 
 Internet-Draft               GREEN-PEM-YANG                    July 2026
 
@@ -1565,7 +1621,7 @@ Internet-Draft               GREEN-PEM-YANG                    July 2026
 
 
 
-Benoit, et al.           Expires 3 January 2027                [Page 28]
+Benoit, et al.           Expires 3 January 2027                [Page 29]
 
 Internet-Draft               GREEN-PEM-YANG                    July 2026
 
@@ -1621,7 +1677,7 @@ Internet-Draft               GREEN-PEM-YANG                    July 2026
 
 
 
-Benoit, et al.           Expires 3 January 2027                [Page 29]
+Benoit, et al.           Expires 3 January 2027                [Page 30]
 
 Internet-Draft               GREEN-PEM-YANG                    July 2026
 
@@ -1677,7 +1733,7 @@ Internet-Draft               GREEN-PEM-YANG                    July 2026
 
 
 
-Benoit, et al.           Expires 3 January 2027                [Page 30]
+Benoit, et al.           Expires 3 January 2027                [Page 31]
 
 Internet-Draft               GREEN-PEM-YANG                    July 2026
 
@@ -1733,7 +1789,7 @@ Internet-Draft               GREEN-PEM-YANG                    July 2026
 
 
 
-Benoit, et al.           Expires 3 January 2027                [Page 31]
+Benoit, et al.           Expires 3 January 2027                [Page 32]
 
 Internet-Draft               GREEN-PEM-YANG                    July 2026
 
@@ -1789,7 +1845,7 @@ Internet-Draft               GREEN-PEM-YANG                    July 2026
 
 
 
-Benoit, et al.           Expires 3 January 2027                [Page 32]
+Benoit, et al.           Expires 3 January 2027                [Page 33]
 
 Internet-Draft               GREEN-PEM-YANG                    July 2026
 
@@ -1845,7 +1901,7 @@ Internet-Draft               GREEN-PEM-YANG                    July 2026
 
 
 
-Benoit, et al.           Expires 3 January 2027                [Page 33]
+Benoit, et al.           Expires 3 January 2027                [Page 34]
 
 Internet-Draft               GREEN-PEM-YANG                    July 2026
 
@@ -1901,7 +1957,7 @@ Internet-Draft               GREEN-PEM-YANG                    July 2026
 
 
 
-Benoit, et al.           Expires 3 January 2027                [Page 34]
+Benoit, et al.           Expires 3 January 2027                [Page 35]
 
 Internet-Draft               GREEN-PEM-YANG                    July 2026
 
@@ -1957,7 +2013,7 @@ Internet-Draft               GREEN-PEM-YANG                    July 2026
 
 
 
-Benoit, et al.           Expires 3 January 2027                [Page 35]
+Benoit, et al.           Expires 3 January 2027                [Page 36]
 
 Internet-Draft               GREEN-PEM-YANG                    July 2026
 
@@ -2013,4 +2069,4 @@ Authors' Addresses
 
 
 
-Benoit, et al.           Expires 3 January 2027                [Page 36]
+Benoit, et al.           Expires 3 January 2027                [Page 37]


### PR DESCRIPTION
Issue 37
From the May 25th 2026 meeting minutes

    Looking at Q2: Relationship between devices. Should they be configurable?
        Rob: My suggestion is no, keep relationship between devices to the controller level rather than the device level. In case of relationship between LC and switchcard this should be populated by the device directly in the operational data.
        Benoit: I'm happy with this direction.
        General agreement between others on the call.

We should have some text around

Regards, Benoit