### PR TITLE
remove ietf letters from iana yang module

### DIFF
--- a/yang/iana-power-and-energy.yang
+++ b/yang/iana-power-and-energy.yang
@@ -1,6 +1,6 @@
-module iana-ietf-power-and-energy {
+module iana-power-and-energy {
   yang-version 1.1;
-  namespace "urn:ietf:params:xml:ns:yang:iana-ietf-power-and-energy";
+  namespace "urn:ietf:params:xml:ns:yang:iana-power-and-energy";
   prefix ianaeo;
 
   organization "IANA";


### PR DESCRIPTION
There are still two legacy ietf letters which were not removed correctly before. 